### PR TITLE
Specify the package name in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ Home = "https://github.com/dusty-phillips/match-variant"
 
 [project.optional-dependencies]
 test = ["pytest"]
+
+[tool.flit.module]
+name = "match_variant"


### PR DESCRIPTION
Allows editable installs to work, e.g. `pip install -e .[test]`.